### PR TITLE
Dropping Node.js 0.10 and 0.12 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
   - 4
   - 5
 notifications:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/hairyhenderson/node-fellowshipone/issues"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=4.2.6"
+  },
   "dependencies": {
     "async": "^1.5.2",
     "debug": "^2.2.0",


### PR DESCRIPTION
This is in anticipation of adding Promise support - related to #37...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>